### PR TITLE
suffix wildcards, and other updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = ['snakebids @ git+https://github.com/akhanf/snakebids.git@90b8a14bb4245e7a69d25745062848bef7a6182a',
-                    pydicom ]
+                'pydicom' ]
 
 setup_requirements = [ ]
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['snakebids @ git+https://github.com/akhanf/snakebids.git@90b8a14bb4245e7a69d25745062848bef7a6182a' ]
+requirements = ['snakebids @ git+https://github.com/akhanf/snakebids.git@90b8a14bb4245e7a69d25745062848bef7a6182a',
+                    pydicom ]
 
 setup_requirements = [ ]
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['snakebids==0.2.1' ]
+requirements = ['snakebids @ git+https://github.com/akhanf/snakebids.git@90b8a14bb4245e7a69d25745062848bef7a6182a' ]
 
 setup_requirements = [ ]
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['snakebids @ git+https://github.com/akhanf/snakebids.git@suffix_wildcard',
+requirements = ['snakebids==0.3.0',
                 'pydicom' ]
 
 setup_requirements = [ ]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['snakebids @ git+https://github.com/akhanf/snakebids.git@90b8a14bb4245e7a69d25745062848bef7a6182a',
+requirements = ['snakebids @ git+https://github.com/akhanf/snakebids.git@suffix_wildcard',
                 'pydicom' ]
 
 setup_requirements = [ ]

--- a/snakebids2dicom/config/snakebids.yml
+++ b/snakebids2dicom/config/snakebids.yml
@@ -21,28 +21,18 @@ targets_by_analysis_level:
 #    https://bids-standard.github.io/pybids/generated/bids.layout.BIDSLayout.html#bids.layout.BIDSLayout.get
 
 pybids_inputs:
-  T1map:
+  scan:
     filters:
       datatype: anat
-      extension: .nii
+      extension: .nii.gz
       invalid_filters: allow
       scope: raw
-      suffix: T1map
     wildcards:
     - subject
     - session
     - acquisition
-  T2map:
-    filters:
-      datatype: anat
-      extension: .nii
-      invalid_filters: allow
-      scope: raw
-      suffix: T2map
-    wildcards:
-    - subject
-    - session
-    - acquisition
+    - suffix
+
 
 #configuration for the command-line parameters to make available
 # passed on the argparse add_argument()
@@ -86,7 +76,15 @@ parse_args:
     nargs: '+'
 
   # Custom command-line params
-
+  --studyinstanceuid:
+    help: 'studyinstanceuid'
+  --orthancurl:
+    help: 'URL for orthanc dicom server' 
+  --orthancusername:
+    help: 'Username for orthanc dicom server' 
+  --orthancpassword:
+    help: 'Password for orthanc dicom server' 
+  
   --push_to_orthanc:
     help: 'Flag to push the result dicoms to a configured Orthanc server.'
     action: 'store_true'

--- a/snakebids2dicom/config/snakebids.yml
+++ b/snakebids2dicom/config/snakebids.yml
@@ -76,8 +76,6 @@ parse_args:
     nargs: '+'
 
   # Custom command-line params
-  --studyinstanceuid:
-    help: 'studyinstanceuid'
   --orthancurl:
     help: 'URL for orthanc dicom server' 
   --orthancusername:

--- a/snakebids2dicom/workflow/Snakefile
+++ b/snakebids2dicom/workflow/Snakefile
@@ -21,7 +21,7 @@ wildcard_constraints:  **snakebids.get_wildcard_constraints(config['pybids_input
 def get_all_input():
     if config["push_to_orthanc"]:
         return {
-            "t1": expand(
+            "scan": expand(
                 bids(
                     root="orthanc_push",
                     desc="done",
@@ -33,7 +33,7 @@ def get_all_input():
           }
     else:
         return {
-            "t1": expand(
+            "scan": expand(
                 bids(
                     root="dicom",
                     **config["input_wildcards"]["scan"],

--- a/snakebids2dicom/workflow/Snakefile
+++ b/snakebids2dicom/workflow/Snakefile
@@ -1,11 +1,22 @@
+
 import snakebids
 from snakebids import bids
 
-configfile: "config/snakebids.yml"
 
-snakebids.generate_inputs_config(config)
+configfile: 'config/snakebids.yml'
 
-wildcard_constraints: **snakebids.get_wildcard_constraints(config)
+#writes inputs_config.yml and updates config dict
+config.update(snakebids.generate_inputs(bids_dir=config['bids_dir'],
+                            pybids_inputs=config['pybids_inputs'],
+                            derivatives=config['derivatives'],
+                            participant_label=config['participant_label'],
+                            exclude_participant_label=config['exclude_participant_label']))
+
+
+#this adds constraints to the bids naming
+wildcard_constraints:  **snakebids.get_wildcard_constraints(config['pybids_inputs'])
+
+
 
 def get_all_input():
     if config["push_to_orthanc"]:
@@ -13,69 +24,38 @@ def get_all_input():
             "t1": expand(
                 bids(
                     root="orthanc_push",
-                    datatype="anat",
-                    acq="{acq}",
-                    suffix="T1map.done",
-                    **config["subj_wildcards"]
+                    desc="done",
+                    **config["input_wildcards"]["scan"],
                 ),
                 zip,
-                **config["input_zip_lists"]["T1map"]
+                **config["input_zip_lists"]["scan"]
             ),
-            "t2": expand(
-                bids(
-                    root="orthanc_push",
-                    datatype="anat",
-                    acq="{acq}",
-                    suffix="T2map.done",
-                    **config["subj_wildcards"]
-                ),
-                zip,
-                **config["input_zip_lists"]["T2map"]
-            )
-        }
+          }
     else:
         return {
             "t1": expand(
                 bids(
                     root="dicom",
-                    datatype="anat",
-                    acq="{acq}",
-                    suffix="T1map",
-                    **config["subj_wildcards"]
+                    **config["input_wildcards"]["scan"],
                 ),
                 zip,
-                **config["input_zip_lists"]["T1map"],
+                **config["input_zip_lists"]["scan"],
             ),
-            "t2": expand(
-                bids(
-                    root="dicom",
-                    datatype="anat",
-                    acq="{acq}",
-                    suffix="T2map",
-                    **config["subj_wildcards"]
-                ),
-                zip,
-                **config["input_zip_lists"]["T2map"],
-            )
-        }
+       }
+
 
 rule all:
     input:
         **get_all_input()
 
-# Having a separate rule for T1 maps and T2 maps is a little awkward, but 
-# Snakebids doesn't seem to handle suffixes as wildcards very well.
-rule nifti2dicom_t1:
+rule nifti2dicom:
     input:
-        config["input_path"]["T1map"]
+        config["input_path"]["scan"]
     output:
         directory(
             bids(
                 root="dicom",
-                datatype="anat",
-                acq="{acq}",
-                suffix="T1map",
-                **config["subj_wildcards"]
+                **config["input_wildcards"]["scan"],
             )
         )
     container:
@@ -83,64 +63,21 @@ rule nifti2dicom_t1:
     shell:
         "nifti2dicom -i {input} -o {output} -y --studyinstanceuid {config[studyinstanceuid]} --patientname {wildcards.subject}"
 
-rule nifti2dicom_t2:
-    input:
-        config["input_path"]["T2map"]
-    output:
-        directory(
-            bids(
-                root="dicom",
-                datatype="anat",
-                acq="{acq}",
-                suffix="T2map",
-                **config["subj_wildcards"]
-            )
-        )
-    container:
-        "docker://tristankk/nifti2dicom:0.4.11"
-    shell:
-        "nifti2dicom -i {input} -o {output} -y --studyinstanceuid {config[studyinstanceuid]} --patientname {wildcards.subject}"
-
-rule push_to_orthanc_t1:
+rule push_to_orthanc:
     input:
         bids(
             root="dicom",
-            datatype="anat",
-            acq="{acq}",
-            suffix="T1map",
-            **config["subj_wildcards"]
+            **config["input_wildcards"]["scan"],
         )
     output:
         touch(
             bids(
                 root="orthanc_push",
-                datatype="anat",
-                acq="{acq}",
-                suffix="T1map.done",
-                **config["subj_wildcards"]
+                desc="done",
+                **config["input_wildcards"]["scan"],
             )
         )
     script:
         "scripts/push_dicoms_to_orthanc.py"
 
-rule push_to_orthanc_t2:
-    input:
-        bids(
-            root="dicom",
-            datatype="anat",
-            acq="{acq}",
-            suffix="T2map",
-            **config["subj_wildcards"]
-        )
-    output:
-        touch(
-            bids(
-                root="orthanc_push",
-                datatype="anat",
-                acq="{acq}",
-                suffix="T2map.done",
-                **config["subj_wildcards"]
-            )
-        )
-    script:
-        "scripts/push_dicoms_to_orthanc.py"
+

--- a/snakebids2dicom/workflow/Snakefile
+++ b/snakebids2dicom/workflow/Snakefile
@@ -48,9 +48,19 @@ rule all:
     input:
         **get_all_input()
 
+
+def get_studyinstanceuid(wildcards):
+    
+    from pydicom.uid import generate_uid
+    #generate unique uid based on subj wildcards (ie unique for subject/session)
+    generate_uid(entropy_srcs=config['subj_wildcards'].keys())
+
+
 rule nifti2dicom:
     input:
         config["input_path"]["scan"]
+    params:
+        studyinstanceuid = get_studyinstanceuid
     output:
         directory(
             bids(
@@ -61,7 +71,7 @@ rule nifti2dicom:
     container:
         "docker://tristankk/nifti2dicom:0.4.11"
     shell:
-        "nifti2dicom -i {input} -o {output} -y --studyinstanceuid {config[studyinstanceuid]} --patientname {wildcards.subject}"
+        "nifti2dicom -i {input} -o {output} -y --studyinstanceuid {params.studyinstanceuid} --patientname {wildcards.subject}"
 
 rule push_to_orthanc:
     input:


### PR DESCRIPTION
- made suffix a wildcard (relies on suffix_wildcard branch in snakebids right now)
- with this change, I replaced T1map and T2map with a generic "scan" 
- removed the now redundant rules, and used `config['input_wildcards']['scan']` (since we want to iterate over scans) instead of subj_wildcards + acq/suffix/datatype
- used pydicom to generate a studyinstanceuid, using `config['subj_wildcards']` to get the unique ID
- added orthanc options to CLI

Was able to push to the test server with this! I did it from my home computer since that's an allowable IP, but we should also add graham's IP range. Also, will need to allow some customization of orientation in the 2D dicoms (e.g. coronal, axial, sagittal), as the test case I tried was a 2D coronal flair acquisition, but the dicoms turned out being axial -- I'll create a separate issue for this